### PR TITLE
Removed bottom margin from start link

### DIFF
--- a/src/components/HomeView/HomeView.scss
+++ b/src/components/HomeView/HomeView.scss
@@ -8,7 +8,6 @@
 }
 
 .home-view > a {
-    margin-bottom: 10vh;
     font-size: calc(2vw + 20px);
     letter-spacing: 5px;
     color: #00ACB5;


### PR DESCRIPTION
The START link on the first page has a large bottom margin, which causes scrollbars to appear at the bottom and right side of the window. If I remove it, the page looks exactly the same as before, but without the scrollbars.
Tested in Google Chrome Version 85.0.4183.102 on Ubuntu.

![image](https://user-images.githubusercontent.com/36840705/95041038-da960e80-06d5-11eb-940f-d3b3114afd29.png)
