### PR TITLE
Fix typo "letting recruiters and team leaders to learn" -> "letting recruiters and team leaders learn"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Developers & engineers - this one is for you!
 
 * Have you always wanted to have an online CV that looks cool? 
 * Do you want your CV to shine above other candidates? 
-* Have you ever dreamed about letting **recruiters** and **team leaders** to learn about your resume by running SQL queries / requesting the data from Swagger / looking at an HTML page building itself? (Probably no.)
+* Have you ever dreamed about letting **recruiters** and **team leaders** learn about your resume by running SQL queries / requesting the data from Swagger / looking at an HTML page building itself? (Probably no.)
 
 If the answer to one of the above is either **YES** || **MAYBE**, click the link below, and prepared to be amazed:
 

--- a/src/components/HomeView/HomeView.tsx
+++ b/src/components/HomeView/HomeView.tsx
@@ -65,7 +65,7 @@ export function HomeView() {
           <ul>
             <li>Have you always wanted to have an online CV that looks cool?</li>
             <li>Do you want your CV to shine above other candidates?</li>
-            <li>Have you ever dreamed about letting recruiters and team leaders to learn about your resume by running SQL queries / playing a game / looking at an HTML page building itself? (Probably no.)</li>
+            <li>Have you ever dreamed about letting recruiters and team leaders learn about your resume by running SQL queries / playing a game / looking at an HTML page building itself? (Probably no.)</li>
           </ul>
           <p>
             If the answer to one of the above is either (<strong>YES</strong> || <strong>MAYBE</strong>), <br />click the button below, and prepared to be amazed:


### PR DESCRIPTION
Main page has a grammar mistake it should be "letting ... learn" and not "letting ... to learn"